### PR TITLE
Backup functionality for the Server manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download the container by cloning the repo and setting permissions:
 ```bash
 $ git clone https://github.com/AziXus/ASA_Server_Docker.git
 $ cd ASA_Server_Docker
-$ sudo chown -R 1000:1000 ./ark_data
+$ sudo chown -R 1000:1000 ./ark_*/
 ```
 
 Before starting the container, edit the [.env](./.env) file to customize the starting parameters of the server. You may also edit [Game.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/Game.ini) and [GameUserSettings.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini) for additional settings. Once this is done, start the container as follow:
@@ -103,6 +103,45 @@ Starting server on port 7790
 Server should be up in a few minutes
 ```
 
+**Server create Backup**
+
+The manager supports creating backups of your savegame and all config files. Backups are stores in the ./ark_backup volume. 
+
+_No Server shutdown needed._
+```bash
+./manager.sh backup
+Creating backup. Backups are saved in your ./ark_backup volume.
+Saving world...
+Success!
+Number of backups in path: 6
+Size of Backup folder: 142M     /var/backups/asa-server
+```
+
+**Server restore Backup**
+
+The manager supports restoring a previously created backup. After using `./manager.sh restore` the manager will print out a list of all created backups and simply ask you which one you want to recover from.
+
+_The server automatically get's restarted when restoring to a backup._
+```bash
+./manager.sh restore
+Stopping the server.
+Stopping server gracefully...
+Waiting 30s for the server to stop
+Done
+Here is a list of all your backup archives:
+1 - - - - - File: backup_2023-11-08_19-11-24.tar.gz
+2 - - - - - File: backup_2023-11-08_19-13-09.tar.gz
+3 - - - - - File: backup_2023-11-08_19-36-49.tar.gz
+4 - - - - - File: backup_2023-11-08_20-48-44.tar.gz
+5 - - - - - File: backup_2023-11-08_21-20-19.tar.gz
+6 - - - - - File: backup_2023-11-08_21-21-10.tar.gz
+Please input the number of the archive you want to restore.
+4
+backup_2023-11-08_20-48-44.tar.gz is getting restored ...
+backup restored successfully!
+Starting server on port 7790
+Server should be up in a few minutes
+```
 **RCON commands**
 ```bash
 $ ./manager.sh rcon "Broadcast Hello World"   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - .env
     volumes:
       - ./ark_data:/opt/arkserver
+      - ./ark_backup:/var/backups/asa-server
       - steam_data:/opt/steamcmd
     ports:
       # Port for connections from ARK game client

--- a/manager.sh
+++ b/manager.sh
@@ -11,4 +11,4 @@ container=$($sudo_cmd docker compose ps -q)
 
 # Use docker exec, instead of docker compose exec as the latter does not
 # override env variables.
-$sudo_cmd docker exec --env-file .env "$container" manager "${@}"
+$sudo_cmd docker exec -it --env-file .env "$container" manager "${@}"

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -175,7 +175,7 @@ backup(){
     # saving before creating the backup
     saveworld
     # sleep is nessecary because the server seems to write save files after the saveworld function ends and thus tar runs into errors.
-    sleep 10
+    sleep 5
     # Use backup script
     /opt/manager/manager_backup.sh
 

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -187,6 +187,17 @@ backup(){
     fi
 }
 
+restoreBackup(){
+    echo "Stopping the server."
+    sleep 5
+    # restoring the backup
+    /opt/manager/manager_restore_backup.sh
+    
+    sleep 5
+    start
+}
+
+
 
 # Main function
 main() {
@@ -218,8 +229,11 @@ main() {
         "backup")
             backup
             ;;
+        "restore")
+            restoreBackup
+            ;;
         *)
-            echo "Invalid action. Supported actions: status, start, stop, restart, saveworld, rcon, update, backup."
+            echo "Invalid action. Supported actions: status, start, stop, restart, saveworld, rcon, update, backup, restore."
             exit 1
             ;;
     esac

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -171,7 +171,7 @@ update() {
 }
 
 backup(){
-    echo "Creating backup. Backups are saved in your ark_backup folder"
+    echo "Creating backup. Backups are saved in your ./ark_backup volume."
     # saving before creating the backup
     saveworld
     # sleep is nessecary because the server seems to write save files after the saveworld function ends and thus tar runs into errors.

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -172,16 +172,21 @@ update() {
 
 backup(){
     echo "Creating backup. Backups are saved in your ark_backup folder"
+    # saving before creating the backup
+    saveworld
+    # sleep is nessecary because the server seems to write save files after the saveworld function ends and thus tar runs into errors.
+    sleep 10
     # Use backup script
     /opt/manager/manager_backup.sh
-    
+
     res=$?
-    if[[$res==0]]; then
-        echo "BACKUP CREATED" >> LOG_FILE
+    if [[ $res == 0 ]]; then
+        echo "BACKUP CREATED" >> $LOG_FILE
     else
         echo "creating backup failed"
     fi
 }
+
 
 # Main function
 main() {

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -188,7 +188,8 @@ backup(){
 }
 
 restoreBackup(){
-    if [[$(ls /var/backups/asa-server/ | wc -l) > 0 ]]; then
+    backup_count=$(ls /var/backups/asa-server/ | wc -l)
+    if [[ $backup_count > 0 ]]; then
         echo "Stopping the server."
         stop
         sleep 5

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -176,8 +176,7 @@ backup(){
     /opt/manager/manager_backup.sh
     
     res=$?
-    if[[$res==0]] 
-    then
+    if[[$res==0]]; then
         echo "BACKUP CREATED" >> LOG_FILE
     else
         echo "creating backup failed"

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -172,10 +172,16 @@ update() {
 
 backup(){
     echo "Creating backup. Backups are saved in your ark_backup folder"
+    # Use backup script
+    /opt/manager/manager_backup.sh
     
-    nohup /opt/manager/manager_backup.sh
-
-
+    res=$?
+    if[[$res==0]] 
+    then
+        echo "BACKUP CREATED" >> LOG_FILE
+    else
+        echo "creating backup failed"
+    fi
 }
 
 # Main function

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -188,14 +188,18 @@ backup(){
 }
 
 restoreBackup(){
-    echo "Stopping the server."
-    stop
-    sleep 5
-    # restoring the backup
-    /opt/manager/manager_restore_backup.sh
-    
-    sleep 5
-    start
+    if [[$(ls /var/backups/asa-server/ | wc -l) > 0 ]]; then
+        echo "Stopping the server."
+        stop
+        sleep 5
+        # restoring the backup
+        /opt/manager/manager_restore_backup.sh
+        
+        sleep 5
+        start
+    else
+        echo "You haven't created any backups yet."
+    fi
 }
 
 

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -192,11 +192,11 @@ restoreBackup(){
     if [[ $backup_count > 0 ]]; then
         echo "Stopping the server."
         stop
-        sleep 5
+        sleep 3
         # restoring the backup
         /opt/manager/manager_restore_backup.sh
         
-        sleep 5
+        sleep 2
         start
     else
         echo "You haven't created any backups yet."

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -189,6 +189,7 @@ backup(){
 
 restoreBackup(){
     echo "Stopping the server."
+    stop
     sleep 5
     # restoring the backup
     /opt/manager/manager_restore_backup.sh

--- a/scripts/manager/manager.sh
+++ b/scripts/manager/manager.sh
@@ -170,6 +170,14 @@ update() {
     start
 }
 
+backup(){
+    echo "Creating backup. Backups are saved in your ark_backup folder"
+    
+    nohup /opt/manager/manager_backup.sh
+
+
+}
+
 # Main function
 main() {
     action="$1"
@@ -197,8 +205,11 @@ main() {
         "update") 
             update
             ;;
+        "backup")
+            backup
+            ;;
         *)
-            echo "Invalid action. Supported actions: status, start, stop, restart, saveworld, rcon, update."
+            echo "Invalid action. Supported actions: status, start, stop, restart, saveworld, rcon, update, backup."
             exit 1
             ;;
     esac

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -13,4 +13,4 @@ tar -czf $path/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
 count=$(ls $path | wc -l)
 
 echo "Number of backups in path: ${count}"
-echo "Size of Backup folder: $(du -hs $path)
+echo "Size of Backup folder: $(du -hs $path)"

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -3,7 +3,7 @@ set -ex
 # create backup folder if it not already exists
 mkdir -p /var/backups/asa-server
 
-archive_name=$(date +"%Y-%m-%d %T")
+archive_name=$(date +"%Y-%m-%d_%H-%M-%S")
 
 tar -czf /var/backups/asa-server/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
 

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+# create backup folder if it not already exists
+mkdir -p /var/backups/asa-server
+
+archive_name=(date +"%Y-%m-%d %T")
+
+tar -czf /var/backups/asa-server/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
+
+# count and output existing backups
+
+count=$(ls /var/backups/asa-server/ | wc -l)
+echo $count

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -3,11 +3,12 @@ set -ex
 # create backup folder if it not already exists
 mkdir -p /var/backups/asa-server
 
-archive_name=(date +"%Y-%m-%d %T")
+archive_name=$(date +"%Y-%m-%d %T")
 
 tar -czf /var/backups/asa-server/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
 
 # count and output existing backups
 
 count=$(ls /var/backups/asa-server/ | wc -l)
-echo $count
+
+echo "Number of backups in path: ${count}"

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -e
 # create backup folder if it not already exists
-mkdir -p /var/backups/asa-server
+path="/var/backups/asa-server"
+mkdir -p 
 
 archive_name=$(date +"%Y-%m-%d_%H-%M-%S")
 
-tar -czf /var/backups/asa-server/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
+tar -czf $path/backup_${archive_name}.tar.gz -C /opt/arkserver/ShooterGame Saved
 
 # count and output existing backups
 
-count=$(ls /var/backups/asa-server/ | wc -l)
+count=$(ls $path | wc -l)
 
 echo "Number of backups in path: ${count}"
+echo "Size of Backup folder: $(du -hs $path)

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 # create backup folder if it not already exists
 mkdir -p /var/backups/asa-server
 

--- a/scripts/manager/manager_backup.sh
+++ b/scripts/manager/manager_backup.sh
@@ -2,7 +2,7 @@
 set -e
 # create backup folder if it not already exists
 path="/var/backups/asa-server"
-mkdir -p 
+mkdir -p $path
 
 archive_name=$(date +"%Y-%m-%d_%H-%M-%S")
 

--- a/scripts/manager/manager_restore_backup.sh
+++ b/scripts/manager/manager_restore_backup.sh
@@ -9,7 +9,7 @@ for datei in $(ls $path); do
    i=$((i + 1))
 done
 
-echo "Pleas input the number of the archive you want to restore."
+echo "Please input the number of the archive you want to restore."
 read num
 
 if [[ ! $num =~ ^[0-9]+$ ]] || [[ $num -ge $i ]]; then
@@ -25,7 +25,7 @@ tar -xzf $path/$archive -C /opt/arkserver/ShooterGame/
 res=$?
 
 if [[ $res == 0 ]]; then
-    echo "backup restored successfully!"
+    echo "Backup restored successfully!"
 else
     echo "An Error occured. Restoring failed."
 fi

--- a/scripts/manager/manager_restore_backup.sh
+++ b/scripts/manager/manager_restore_backup.sh
@@ -25,6 +25,7 @@ res=$?
 
 if [[ $res == 0 ]]; then
     echo "backup restored successfully!"
+    echo "RESTORED BACKUP $archive" >> $LOG_FILE
 else
     echo "restoring failed."
 fi

--- a/scripts/manager/manager_restore_backup.sh
+++ b/scripts/manager/manager_restore_backup.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
-
-set -ex
-
+set -e
 i=1
 echo "Here is a list of all your backup files: "
 
 # list all files with a counter
 for datei in $(ls /var/backups/asa-server); do
-   echo "$i - - - - - Datei: $datei"
+   echo "$i - - - - - File: $datei"
    i=$((i + 1))
 done
 

--- a/scripts/manager/manager_restore_backup.sh
+++ b/scripts/manager/manager_restore_backup.sh
@@ -1,29 +1,31 @@
 #!/bin/bash
 set -e
 i=1
-echo "Here is a list of all your backup files: "
-
+echo "Here is a list of all your backup archives: "
+path="/var/backups/asa-server"
 # list all files with a counter
-for datei in $(ls /var/backups/asa-server); do
+for datei in $(ls $path); do
    echo "$i - - - - - File: $datei"
    i=$((i + 1))
 done
 
-echo "which file do you want to choose? (select a number from above according to the backup you want to recover)"
+echo "Pleas input the number of the archive you want to restore."
 read num
 
-archive=$(ls /var/backups/asa-server | sed -n "${num}p")
+if [[ ! $num =~ ^[0-9]+$ ]] || [[ $num -ge $i ]]; then
+    echo "Invalid input. Please enter a valid number."
+    exit 1
+fi
+archive=$(ls $path | sed -n "${num}p")
 
-echo "You've choosen $archive"
-echo "$archive gets restored...."
+echo "$archive is getting restored ..."
 
-tar -xzf /var/backups/asa-server/$archive -C /opt/arkserver/ShooterGame/
+tar -xzf $path/$archive -C /opt/arkserver/ShooterGame/
 
 res=$?
 
 if [[ $res == 0 ]]; then
     echo "backup restored successfully!"
-    echo "RESTORED BACKUP $archive" >> $LOG_FILE
 else
-    echo "restoring failed."
+    echo "An Error occured. Restoring failed."
 fi

--- a/scripts/manager/manager_restore_backup.sh
+++ b/scripts/manager/manager_restore_backup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+i=1
+echo "Here is a list of all your backup files: "
+
+# list all files with a counter
+for datei in $(ls /var/backups/asa-server); do
+   echo "$i - - - - - Datei: $datei"
+   i=$((i + 1))
+done
+
+echo "which file do you want to choose? (select a number from above according to the backup you want to recover)"
+read num
+
+archive=$(ls /var/backups/asa-server | sed -n "${num}p")
+
+echo "You've choosen $archive"
+echo "$archive gets restored...."
+
+tar -xzf /var/backups/asa-server/$archive -C /opt/arkserver/ShooterGame/
+
+res=$?
+
+if [[ $res == 0 ]]; then
+    echo "backup restored successfully!"
+else
+    echo "restoring failed."
+fi

--- a/scripts/manager/manager_server_start.sh
+++ b/scripts/manager/manager_server_start.sh
@@ -41,5 +41,8 @@ fi
 
 ark_flags="${ark_flags} ${ARK_EXTRA_DASH_OPTS}"
 
+#fix for docker compose exec / docker exec parsing inconsistencies
+STEAM_COMPAT_DATA_PATH=$(eval echo "$STEAM_COMPAT_DATA_PATH")
+
 #starting server and outputting log file
 proton run /opt/arkserver/ShooterGame/Binaries/Win64/ArkAscendedServer.exe ${cmd} ${ark_flags} > /dev/null 2>&1


### PR DESCRIPTION
This PR adds a backup function to our existing server manager. #10 

- added `ark_backup` volume in the base dir and `var/backups/asa-server folder` in the container for saving the backups
- using tar.gz for compressing and saving the `/ShooterGame/Saved` directory
- `manager backup` saves the gameworld and creates a backup
- `manager restore`: stops the server, lists all available backups& asks for which one to restore, starts the server again
- edited readme to display new functions
- slightly edited manager.sh for using -it option on docker exec