### PR TITLE
Add service name filter in manager

### DIFF
--- a/manager.sh
+++ b/manager.sh
@@ -7,7 +7,7 @@ fi
 
 # Get the container id first. This is somewhat necessary since the next command
 # does not use docker compose.
-container=$($sudo_cmd docker compose ps -q)
+container=$($sudo_cmd docker compose ps -q asa_server)
 
 # Use docker exec, instead of docker compose exec as the latter does not
 # override env variables.


### PR DESCRIPTION
If someone decides to add services(ftp access to savegame, etc) to the compose file then docker compose ps -q is not working because it returns several services.

Directly specifying the correct service will fix this issue.