### PR TITLE
Added script_dir to manager.sh, allows calling from anywhere

### DIFF
--- a/manager.sh
+++ b/manager.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# Simple wrapper for docker commands to make life easier. 
+# Simple wrapper for docker commands to make life easier.
+set -euo pipefail
+
+script_dir="$(dirname "$(realpath "$0")")"
+
 sudo_cmd=( sudo )
 if [[ "$EUID" -eq 0 ]] || id -nGz "$USER" | grep -qzxF "docker"; then
 	sudo_cmd=()
@@ -7,8 +11,8 @@ fi
 
 # Get the container id first. This is somewhat necessary since the next command
 # does not use docker compose.
-container=$($sudo_cmd docker compose ps -q asa_server)
+container=$($sudo_cmd docker compose -f "$script_dir/docker-compose.yml" ps -q asa_server)
 
 # Use docker exec, instead of docker compose exec as the latter does not
 # override env variables.
-$sudo_cmd docker exec -it --env-file .env "$container" manager "${@}"
+$sudo_cmd docker exec -it --env-file "$script_dir/.env" "$container" manager "${@}"


### PR DESCRIPTION
I tried to create an alias on my server to be able to run the manager.sh from anywhere but it doesn't work, it currently assumes you're running from the same directory. This now allows you to run it from anywhere by using a robust technique to get the directory of the current script and prefixing both the `docker-compose.yml` path and the `.env` path with it.