### PR TITLE
Docs: Added guide for clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the container by cloning the repo and setting permissions:
 ```bash
 $ git clone https://github.com/AziXus/ARK_Ascended_Docker.git
 $ cd ARK_Ascended_Docker
-$ sudo chown -R 1000:1000 .ark_*/
+$ sudo chown -R 1000:1000 ./ark_*/
 ```
 
 Before starting the container, edit the [.env](./.env) file to customize the starting parameters of the server. You may also edit [Game.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/Game.ini) and [GameUserSettings.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini) for additional settings. Once this is done, start the container as follow:
@@ -74,13 +74,22 @@ To increase the available server memory, in [docker-compose.yml](./docker-compos
 If you want to run a cluster with two or more containers running at the same time, you will have to be aware of some things you have to change: 
 - Clone this repository into two different directories like `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder1` and `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder2`
 - First setup all instances according to the [usage](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#usage) and [configuration](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#configuration) steps.
+- Create a folder in a directory of your choosing, e.g., `mkdir -p /opt/clusters`. This folder will be used by both instances to transfer player data.
+- Edit the [docker-compose.yml](./docker-compose.yml) file in every instance by adding a volume for the newly created folder. The updated volume section should look as follows:
+  ```yaml
+  volumes:
+    - ./ark_data:/opt/arkserver
+    - ./ark_backup:/var/backups/asa-server
+    - /opt/clusters:/opt/shared-cluster#<-- This means that data in the container saved in the local /opt/clusters folder get's saved on your host in the previously created /opt/clusters folder
+    - steam_data:/opt/steamcmd
+  ```
 - Edit the [.env](./.env) file in every instance accordingly
   - Set the **port** to a different one for each instance, eg 7777, 7778, 7779 etc.
   - Edit `SERVER_MAP` to the map you want the server to run eg (`TheIsland_WP`, `ScorchedEarth_WP` etc)
   - Add line `COMPOSE_PROJECT_NAME=aprojectname` somewhere in the [.env](./.env) file with a different name for each instance. Please only use small letters, underscores and numbers.
   - Add `-clusterID=[yourclusterid]` to the `ARK_EXTRA_DASH_OPTS` with the same `clusterID` for every instance you want to cluster. The `clusterID` should be a random combination of letters and numbers, don't use special characters. The line should somewhat look like this:
     ```
-    ARK_EXTRA_DASH_OPTS=-ForceAllowCaveFlyers -ForceRespawnDinos -AllowRaidDinoFeeding=true -ActiveEvent=Summer -clusterID=thisisarandomid
+    ARK_EXTRA_DASH_OPTS=-ForceAllowCaveFlyers -ForceRespawnDinos -AllowRaidDinoFeeding=true -ActiveEvent=Summer -clusterID=thisisarandomid -ClusterDirOverride="/opt/shared-cluster"
     ```
 - Be sure that you have at least about **28-32GB** of memory available, especially if you use any mods
 - Start every instance with `docker compose up -d` and enjoy your clustered ASA server :)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 This project relies on GloriousEggroll's Proton-GE in order to run the ARK Survival Ascended Server inside a docker container under Linux. This allows to run the ASA Windows server binaries on Linux easily.
 
+<!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
+### Table of Contents
+- [Usage](#usage)
+- [Configuration](#configuration)
+   * [Configuration variables](#configuration-variables)
+- [Running multiple instances (cluster)](#running-multiple-instances-cluster)
+- [Manager commands](#manager-commands)
+- [Hypervisors](#hypervisors)
 
+<!-- TOC end -->
 ### Usage
 Download the container by cloning the repo and setting permissions:
 ```bash
 $ git clone https://github.com/AziXus/ARK_Ascended_Docker.git
 $ cd ARK_Ascended_Docker
-$ sudo chown -R 1000:1000 ./ark_*/
+$ sudo chown -R 1000:1000 .ark_*/
 ```
 
 Before starting the container, edit the [.env](./.env) file to customize the starting parameters of the server. You may also edit [Game.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/Game.ini) and [GameUserSettings.ini](./ark_data/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini) for additional settings. Once this is done, start the container as follow:
@@ -60,6 +69,20 @@ We list some configuration options that may be used to customize the server belo
 | ARK_EXTRA_DASH_OPTS | Extra dash arguments to add to the startup command. | -ForceAllowCaveFlyers -ForceRespawnDinos -AllowRaidDinoFeeding=true -ActiveEvent=Summer |
 
 To increase the available server memory, in [docker-compose.yml](./docker-compose.yml), increase the `deploy, resources, limits, memory: 16g` to a higher value.
+
+### Running multiple instances (cluster)
+If you want to run a cluster with two or more containers running at the same time, you will have to be aware of some things you have to change: 
+- Clone this repository into two different directories like `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder1` and `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder2`
+- First setup all instances according to the [usage](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#usage) and [configuration](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#configuration) steps.
+- Edit the [.env](./.env) file in every instance accordingly
+  - Set the **port** to a different one for each instance, eg 7777, 7778, 7779 etc.
+  - Add line `COMPOSE_PROJECT_NAME=aprojectname` somewhere in the [.env](./.env) file with a different name for each instance. Please only use small letters, underscores and numbers.
+  - Add `-clusterID=[yourclusterid]` to the `ARK_EXTRA_DASH_OPTS` with the same `clusterID` for every instance you want to cluster. The `clusterID` should be a random combination of letters and numbers, don't use special characters. The line should somewhat look like this:
+    ```
+    ARK_EXTRA_DASH_OPTS=-ForceAllowCaveFlyers -ForceRespawnDinos -AllowRaidDinoFeeding=true -ActiveEvent=Summer -clusterID=thisisarandomid
+    ```
+- Be sure that you have at least about **28-32GB** of memory available, especially if you use any mods
+- Start every instance with `docker compose up -d` and enjoy your clustered ASA server :)
 
 ### Manager commands
 The manager script supports several commands that we highlight below. 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ If you want to run a cluster with two or more containers running at the same tim
 - Clone this repository into two different directories like `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder1` and `git clone https://github.com/azixus/ARK_Ascended_Docker.git folder2`
 - First setup all instances according to the [usage](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#usage) and [configuration](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#configuration) steps.
 - Create a folder in a directory of your choosing, e.g., `mkdir -p /opt/clusters`. This folder will be used by both instances to transfer player data.
-- Edit the [docker-compose.yml](./docker-compose.yml) file in every instance by adding a volume for the newly created folder. The updated volume section should look as follows:
+- Edit the [docker-compose.yml](./docker-compose.yml) file in every instance by adding a volume for the newly created folder. The updated volume section should look as follows (focus on `/opt/clusters....`:
   ```yaml
   volumes:
     - ./ark_data:/opt/arkserver
     - ./ark_backup:/var/backups/asa-server
-    - /opt/clusters:/opt/shared-cluster#<-- This means that data in the container saved in the local /opt/clusters folder get's saved on your host in the previously created /opt/clusters folder
+    - /opt/clusters:/opt/shared-cluster
     - steam_data:/opt/steamcmd
   ```
 - Edit the [.env](./.env) file in every instance accordingly

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If you want to run a cluster with two or more containers running at the same tim
 - First setup all instances according to the [usage](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#usage) and [configuration](https://github.com/azixus/ARK_Ascended_Docker/edit/cluster/README.md#configuration) steps.
 - Edit the [.env](./.env) file in every instance accordingly
   - Set the **port** to a different one for each instance, eg 7777, 7778, 7779 etc.
+  - Edit `SERVER_MAP` to the map you want the server to run eg (`TheIsland_WP`, `ScorchedEarth_WP` etc)
   - Add line `COMPOSE_PROJECT_NAME=aprojectname` somewhere in the [.env](./.env) file with a different name for each instance. Please only use small letters, underscores and numbers.
   - Add `-clusterID=[yourclusterid]` to the `ARK_EXTRA_DASH_OPTS` with the same `clusterID` for every instance you want to cluster. The `clusterID` should be a random combination of letters and numbers, don't use special characters. The line should somewhat look like this:
     ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   asa_server:
     tty: true


### PR DESCRIPTION
Hey there, I've added a guide for clustering/ running multiple instances to the Readme.md file.

Added/Changed:

- Removed `version` from docker-compose.yml because it's now officially obsolete
- Added ToC to readme.md
- Added Guide for clustering to readme.md including
   - changes to the .env file
   - addition of the `COMPOSE_PROJECT_NAME` env variable to ensure docker compose compatibility
   - addition of `clusterID` according to [the ark patchnotes](https://survivetheark.com/index.php?/forums/topic/708761-asa-pc-patch-notes-client-v3623-server-v3627-updated-03292024/#:~:text=If%20you%20are%20running%20your%20own%20cluster%20you%20can%20enable%20this%20with%3A%20-clusterID%3D%5Bclustername%5D)
 - Fixed `chown` command
 

@azixus If you want to further change the .env file (like adding the `COMPOSE_PROJECT_NAME` from the beginning), I'm open to discuss 👍 